### PR TITLE
Enable slashing db prunning

### DIFF
--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -61,7 +61,7 @@ env >>/etc/environment
 # IMPORTANT! The dir defined for --key-store-path must exist and have specific permissions. Should not be created with a docker volume
 mkdir -p "$KEYFILES_DIR"
 
-if grep -Fq "/opt/web3signer/keyfiles" ${KEYFILES_DIR}/*.yaml ;then
+if grep -Fq "/opt/web3signer/keyfiles" ${KEYFILES_DIR}/*.yaml; then
   sed -i "s|/opt/web3signer/keyfiles|$KEYFILES_DIR|g" ${KEYFILES_DIR}/*.yaml
 fi
 
@@ -102,5 +102,6 @@ exec /opt/web3signer/bin/web3signer \
   --slashing-protection-db-url=jdbc:postgresql://postgres.web3signer.dappnode:5432/web3signer-mainnet \
   --slashing-protection-db-username=postgres \
   --slashing-protection-db-password=mainnet \
+  --slashing-protection-pruning-enabled=true \
   --key-manager-api-enabled=true \
   ${EXTRA_OPTS}

--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -103,6 +103,6 @@ exec /opt/web3signer/bin/web3signer \
   --slashing-protection-db-username=postgres \
   --slashing-protection-db-password=mainnet \
   --slashing-protection-pruning-enabled=true \
-  --slashing-protection-pruning-epochs-to-keep=5000 \
+  --slashing-protection-pruning-epochs-to-keep=225 \
   --key-manager-api-enabled=true \
   ${EXTRA_OPTS}

--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -103,5 +103,6 @@ exec /opt/web3signer/bin/web3signer \
   --slashing-protection-db-username=postgres \
   --slashing-protection-db-password=mainnet \
   --slashing-protection-pruning-enabled=true \
+  --slashing-protection-pruning-epochs-to-keep=5000 \
   --key-manager-api-enabled=true \
   ${EXTRA_OPTS}


### PR DESCRIPTION
Enable slashing db prunning. Take as reference the following slashing db flags as web3signer version **22.10.0**
```
      --slashing-protection-db-health-check-interval-milliseconds=<interval in
        milliseconds>
                            Number of milliseconds between the database health
                              check operation (Default: 30000)
      --slashing-protection-db-health-check-timeout-milliseconds=<timeout in
        milliseconds>
                            Number of milliseconds after which the database
                              health check will be failed (Default: 3000)
      --slashing-protection-db-password=<jdbc password>
                            The password to use when connecting to the slashing
                              protection database
      --slashing-protection-db-pool-configuration-file=<hikari configuration
        properties file>
                            Optional configuration file for Hikari database
                              connection pool.
      --slashing-protection-db-url=<jdbc url>
                            The jdbc url to use to connect to the slashing
                              protection database
      --slashing-protection-db-username=<jdbc user>
                            The username to use when connecting to the slashing
                              protection database
      --slashing-protection-enabled=<BOOL>
                            Set to true if all Eth2 signing operations should
                              be validated against historic data, prior to
                              responding with signatures(default: true)
      --slashing-protection-pruning-at-boot-enabled=<BOOL>
                            Set to false to disable slashing protection pruning
                              logic at server boot(default: true)
      --slashing-protection-pruning-enabled=<BOOL>
                            Set to true if all Eth2 slashing protection
                              database should be pruned (default: false)
      --slashing-protection-pruning-epochs-to-keep=<pruningEpochsToKeep>
                            Number of epochs to keep. (default: 10000)
      --slashing-protection-pruning-interval=<pruningInterval>
                            Hours between pruning operations (default: 24)
      --slashing-protection-pruning-slots-per-epoch=<pruningSlotsPerEpoch>
                            Slots per epoch to use when calculating the number
                              of slots to prune for signed blocks. This
                              typically will not need changing and defaults to
                              value used on mainnet (default: 32)
```