### PR TITLE
Add `flyway` to migrate on the fly and bump to 23.3.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "web3signer.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "23.2.0",
+  "upstreamVersion": "23.3.0",
   "architectures": ["linux/amd64"],
   "upstreamRepo": "ConsenSys/web3signer",
   "mainService": "web3signer",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "web3signer.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "23.3.0",
+  "upstreamVersion": "23.3.1",
   "architectures": ["linux/amd64"],
   "upstreamRepo": "ConsenSys/web3signer",
   "mainService": "web3signer",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,10 +52,8 @@ services:
     user: postgres
     volumes:
       - "postgres_data:/var/lib/postgresql/data"
-      - "postgres_migrations:/docker-entrypoint-initdb.d"
     restart: unless-stopped
 volumes:
   brain_data: {}
   web3signer_data: {}
   postgres_data: {}
-  postgres_migrations: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,8 @@ services:
       context: web3signer
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION: 23.3.0
+        UPSTREAM_VERSION: 23.3.1
     environment:
-      LOG_TYPE: INFO
       EXTRA_OPTS: ""
     volumes:
       - "web3signer_data:/data"
@@ -42,7 +41,7 @@ services:
       context: flyway
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION: 23.3.0
+        UPSTREAM_VERSION: 23.3.1
     depends_on:
       postgres:
         condition: service_started
@@ -59,7 +58,7 @@ services:
       context: postgres
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION: 23.3.0
+        UPSTREAM_VERSION: 23.3.1
     user: postgres
     volumes:
       - "postgres_data:/var/lib/postgresql/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,21 +22,32 @@ services:
       timeout: 5s
       retries: 100
     depends_on:
-      postgres:
-        condition: service_started
+      flyway:
+        condition: service_completed_successfully
     security_opt:
       - "seccomp:unconfined"
     build:
       context: web3signer
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION: 23.2.0
+        UPSTREAM_VERSION: 23.3.0
     environment:
       LOG_TYPE: INFO
       EXTRA_OPTS: ""
     volumes:
       - "web3signer_data:/data"
     restart: unless-stopped
+  flyway:
+    build:
+      context: flyway
+      dockerfile: Dockerfile
+      args:
+        UPSTREAM_VERSION: 23.3.0
+    depends_on:
+      postgres:
+        condition: service_started
+    image: "flyway.web3signer.dnp.dappnode.eth:0.1.0"
+    restart: on-failure
   postgres:
     image: "postgres.web3signer.dnp.dappnode.eth:0.1.0"
     healthcheck:
@@ -48,7 +59,7 @@ services:
       context: postgres
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION: 23.2.0
+        UPSTREAM_VERSION: 23.3.0
     user: postgres
     volumes:
       - "postgres_data:/var/lib/postgresql/data"

--- a/flyway/Dockerfile
+++ b/flyway/Dockerfile
@@ -18,7 +18,7 @@ RUN wget -q https://github.com/ConsenSys/web3signer/archive/refs/tags/${UPSTREAM
 FROM flyway/flyway:9.16.1-alpine
 ARG UPSTREAM_VERSION
 RUN apk update && apk add postgresql-client
-COPY --from=postgres-migrations /usr/src/app/web3signer-${UPSTREAM_VERSION}/slashing-protection/src/main/resources/migrations/postgresql/* /flyway/sql/
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh && rm /flyway/sql/put-your-sql-migrations-here.txt
+COPY --from=postgres-migrations /usr/src/app/web3signer-${UPSTREAM_VERSION}/slashing-protection/src/main/resources/migrations/postgresql/* /flyway/sql/
 ENTRYPOINT ["entrypoint.sh"]

--- a/flyway/Dockerfile
+++ b/flyway/Dockerfile
@@ -1,0 +1,24 @@
+ARG UPSTREAM_VERSION
+
+##############
+# MIGRATIONS #
+##############
+FROM debian:bullseye-slim as postgres-migrations
+ARG UPSTREAM_VERSION
+WORKDIR /usr/src/app
+RUN apt update && apt install -y wget
+# Get migrations from consensys web3signer repo
+# path is /usr/src/app/web3signer-21.10.0/slashing-protection/src/main/resources/migrations/postgresql
+RUN wget -q https://github.com/ConsenSys/web3signer/archive/refs/tags/${UPSTREAM_VERSION}.tar.gz && \
+    tar -xvf ${UPSTREAM_VERSION}.tar.gz
+
+##########
+# FLYWAY #
+##########
+FROM flyway/flyway:9.16.1-alpine
+ARG UPSTREAM_VERSION
+RUN apk update && apk add postgresql-client
+COPY --from=postgres-migrations /usr/src/app/web3signer-${UPSTREAM_VERSION}/slashing-protection/src/main/resources/migrations/postgresql/* /flyway/sql/
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh && rm /flyway/sql/put-your-sql-migrations-here.txt
+ENTRYPOINT ["entrypoint.sh"]

--- a/flyway/entrypoint.sh
+++ b/flyway/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Get postgresql database version and trim whitespaces
+DATABASE_VERSION=$(PGPASSWORD=password psql --tuples-only -U postgres -h postgres.web3signer.dappnode -p 5432 -d web3signer -c "SELECT version FROM database_version WHERE id=1;" | awk '{print $1}' | tr -d '[:space:]')
+
+# Get the latest migration file version
+LATEST_MIGRATION_VERSION=$(ls -1 /flyway/sql/ | tail -n 1 | cut -d'_' -f1 | cut -d'V' -f2 | sed 's/^0*//')
+
+# Ensure that either DATABASE_VERSION and LATEST_MIGRATION_VERSION are integers
+if ! [[ "$DATABASE_VERSION" =~ ^[0-9]+$ ]] || ! [[ "$LATEST_MIGRATION_VERSION" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: could not compare database and latest migration file versions. Exiting WITHOUT DATABASE MIGRATIONS. This may result in unexpected behaviour"
+  exit 0
+fi
+
+if [ "$DATABASE_VERSION" -ge "$LATEST_MIGRATION_VERSION" ]; then
+  echo "Database version is greater or equal to the latest migration file version. Exiting..."
+  exit 0
+else
+  echo "Database version is less than the latest migration file version. Migrating..."
+  echo "Database version: $DATABASE_VERSION"
+  echo "Latest migration file version: $LATEST_MIGRATION_VERSION"
+  flyway -baselineOnMigrate="true" -baselineVersion="${DATABASE_VERSION}" -url=jdbc:postgresql://postgres.web3signer.dappnode:5432/web3signer -user=postgres -password=password -connectRetries=60 migrate
+  echo "Migration completed"
+  exit 0
+fi

--- a/flyway/entrypoint.sh
+++ b/flyway/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get postgresql database version and trim whitespaces
-DATABASE_VERSION=$(PGPASSWORD=password psql --tuples-only -U postgres -h postgres.web3signer.dappnode -p 5432 -d web3signer -c "SELECT version FROM database_version WHERE id=1;" | awk '{print $1}' | tr -d '[:space:]')
+DATABASE_VERSION=$(PGPASSWORD=mainnet psql --tuples-only -U postgres -h postgres.web3signer.dappnode -p 5432 -d web3signer-mainnet -c "SELECT version FROM database_version WHERE id=1;" | awk '{print $1}' | tr -d '[:space:]')
 
 # Get the latest migration file version
 LATEST_MIGRATION_VERSION=$(ls -1 /flyway/sql/ | tail -n 1 | cut -d'_' -f1 | cut -d'V' -f2 | sed 's/^0*//')
@@ -19,7 +19,7 @@ else
   echo "Database version is less than the latest migration file version. Migrating..."
   echo "Database version: $DATABASE_VERSION"
   echo "Latest migration file version: $LATEST_MIGRATION_VERSION"
-  flyway -baselineOnMigrate="true" -baselineVersion="${DATABASE_VERSION}" -url=jdbc:postgresql://postgres.web3signer.dappnode:5432/web3signer -user=postgres -password=password -connectRetries=60 migrate
+  flyway -baselineOnMigrate="true" -baselineVersion="${DATABASE_VERSION}" -url=jdbc:postgresql://postgres.web3signer.dappnode:5432/web3signer-mainnet -user=postgres -password=mainnet -connectRetries=60 migrate
   echo "Migration completed"
   exit 0
 fi

--- a/flyway/entrypoint.sh
+++ b/flyway/entrypoint.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+set -e
+
 # Get postgresql database version and trim whitespaces
 DATABASE_VERSION=$(PGPASSWORD=mainnet psql --tuples-only -U postgres -h postgres.web3signer.dappnode -p 5432 -d web3signer-mainnet -c "SELECT version FROM database_version WHERE id=1;" | awk '{print $1}' | tr -d '[:space:]')
 
 # Get the latest migration file version
-LATEST_MIGRATION_VERSION=$(ls -1 /flyway/sql/ | tail -n 1 | cut -d'_' -f1 | cut -d'V' -f2 | sed 's/^0*//')
+LATEST_MIGRATION_VERSION=$(ls -1 /flyway/sql/ | grep -E "V[0-9]+__.*.sql$" | tail -n 1 | cut -d'_' -f1 | cut -d'V' -f2 | sed 's/^0*//' | tr -d '[:space:]')
 
 # Ensure that either DATABASE_VERSION and LATEST_MIGRATION_VERSION are integers
 if ! [[ "$DATABASE_VERSION" =~ ^[0-9]+$ ]] || ! [[ "$LATEST_MIGRATION_VERSION" =~ ^[0-9]+$ ]]; then
@@ -12,12 +14,13 @@ if ! [[ "$DATABASE_VERSION" =~ ^[0-9]+$ ]] || ! [[ "$LATEST_MIGRATION_VERSION" =
   exit 0
 fi
 
+echo "Database version: $DATABASE_VERSION"
+echo "Latest migration file version: $LATEST_MIGRATION_VERSION"
+
 if [ "$DATABASE_VERSION" -ge "$LATEST_MIGRATION_VERSION" ]; then
   echo "Database version is greater or equal to the latest migration file version. Exiting..."
   exit 0
 else
-  echo "Database version is less than the latest migration file version. Migrating..."
-  echo "Database version: $DATABASE_VERSION"
   echo "Latest migration file version: $LATEST_MIGRATION_VERSION"
   flyway -baselineOnMigrate="true" -baselineVersion="${DATABASE_VERSION}" -url=jdbc:postgresql://postgres.web3signer.dappnode:5432/web3signer-mainnet -user=postgres -password=mainnet -connectRetries=60 migrate
   echo "Migration completed"


### PR DESCRIPTION
Some migrations must be executed once the db is running, to do that: 
- Add a new service with `flyway` to perform those migrations on the fly. 
- Also, make the signer service dependant on this flyway service.
- Remove the migrations volume