### PR TITLE
Bump brain 0.1.17

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.16
+FROM ghcr.io/dappnode/staking-brain:0.1.17
 ENV NETWORK=mainnet

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -30,7 +30,10 @@
   },
   "license": "Apache-2.0",
   "requirements": {
-    "minimumDappnodeVersion": "0.2.69"
+    "minimumDappnodeVersion": "0.2.89"
+  },
+  "optionalDependecies": {
+    "prysm.dnp.dappnode.eth": "3.0.15"
   },
   "warnings": {
     "onMajorUpdate": "This update will do a migration, it is recommended to have a backup of your keystores (http://my.dappnode/#/packages/web3signer.dnp.dappnode.eth/backup)",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -32,7 +32,7 @@
   "requirements": {
     "minimumDappnodeVersion": "0.2.89"
   },
-  "optionalDependecies": {
+  "optionalDependencies": {
     "prysm.dnp.dappnode.eth": "3.0.15"
   },
   "warnings": {


### PR DESCRIPTION
Bump brain to `v0.1.17` to match new auth-token for Prysm validator