### PR TITLE
Bump brain to 0.1.19

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.17
+FROM ghcr.io/dappnode/staking-brain:0.1.19
 ENV NETWORK=mainnet


### PR DESCRIPTION
Bump brain to 0.1.19 so that the Stakewise operator can upload the keystores to the signer